### PR TITLE
[new_dataset] SCF_plus_mini_no_weights

### DIFF
--- a/SCF_plus/SCF_plus_mini_no_weights.csv
+++ b/SCF_plus/SCF_plus_mini_no_weights.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3b2c78afa4b6cf87fb885947681fd8e54bbe6ee736fce0aaafccdc75788a0a6
+size 75902999

--- a/SCF_plus/generating_mini.md
+++ b/SCF_plus/generating_mini.md
@@ -11,8 +11,6 @@ kernelspec:
   name: python3
 ---
 
-
-
 Regarding converting between ``.ipynb`` and ``.md`` please refer to https://manual.quantecon.org/writing/converting.html
 
 ```{code-cell} ipython3
@@ -49,8 +47,33 @@ df1.columns = var_names_new
 df1
 ```
 
+Export the dataset with weights.
+
 ```{code-cell} ipython3
-df1.to_csv('SCF_plus_mini.csv', index=None)
+# df1.to_csv('SCF_plus_mini.csv', index=None)  # use it when you want to export the weighted data
+```
+
+Generate and export the dataset without weights.
+
+```{code-cell} ipython3
+counts = list(round(df1['weights'])) 
+df1["weights"] = counts
+```
+
+```{code-cell} ipython3
+df2 = df1.loc[df1.index.repeat(df1.weights)].reset_index(drop=True)
+```
+
+```{code-cell} ipython3
+df2 = df2.drop(columns=['weights'])
+```
+
+```{code-cell} ipython3
+df2
+```
+
+```{code-cell} ipython3
+# df2.to_csv('SCF_plus_mini_no_weights.csv', index=None)  # use it when you want to export the non weighted data
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
As discussed with @jstac and @maanasee this PR produces a dataset called ``SCF_plus_mini_no_weights.csv`` along with its generating file [generating_mini.md](https://github.com/QuantEcon/high_dim_data/blob/update_scf_noweights/SCF_plus/generating_mini.md).